### PR TITLE
[Change]tags=httpd_installのみで起動するよう修正

### DIFF
--- a/roles/httpd/httpd_install/tasks/main.yml
+++ b/roles/httpd/httpd_install/tasks/main.yml
@@ -7,3 +7,4 @@
   systemd:
     name: httpd
     enabled: yes
+    state: started


### PR DESCRIPTION
AnsiblePlaybook実行② webサーバへhttpdインストール
↓
AnsiblePlaybook実行③ webサーバへhttpdインストール後の確認の際に
stateの設定ないままだとapache起動しないため修正

```
[ec2-user@ip-10-0-0-44 ~]$ sudo systemctl status httpd
○ httpd.service - The Apache HTTP Server
     Loaded: loaded (/usr/lib/systemd/system/httpd.service; enabled; preset: disabled)
     Active: inactive (dead)
       Docs: man:httpd.service(8)
[ec2-user@ip-10-0-0-44 ~]$
```
